### PR TITLE
Increase minimum Rust version to v1.53.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # This is the "Minimum Supported Rust Version" for this project.
 # Increasing it should be considered a breaking change and requires a new
 # major version release.
-channel = "1.46.0"
+channel = "1.53.0"


### PR DESCRIPTION
This is unfortunately required by https://github.com/getsentry/sentry-rust/releases/tag/0.24.1