### PR TITLE
Update minimum Rust version to v1.57.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/Turbo87/sentry-conduit.git"
 keywords = ["sentry", "conduit", "error"]
 edition = "2018"
-rust-version = "1.53.0"
+rust-version = "1.57.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Features
 MSRV
 ------------------------------------------------------------------------------
 
-The "Minimum Supported Rust Version" of this project is: v1.53.0
+The "Minimum Supported Rust Version" of this project is: v1.57.0
 
 
 Usage

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # This is the "Minimum Supported Rust Version" for this project.
 # Increasing it should be considered a breaking change and requires a new
 # major version release.
-channel = "1.53.0"
+channel = "1.57.0"


### PR DESCRIPTION
This enables us to upgrade to Sentry v0.27.0